### PR TITLE
Support rendering from url param selections

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,9 +2,72 @@ import * as React from "react";
 import ArraySelector from "./components/array-selector";
 import ArrayRenderer from "./components/array-renderer";
 import { useApplicationState } from "./state";
+import * as zarr from "zarrita";
+import { coordsFromZarr } from "./lib/larray";
+import { useEffect, useState } from "react";
+
+const getCoords = async(storePath) => {
+  let store = await zarr.withConsolidated(new zarr.FetchStore(storePath));
+  const node = await zarr.open.v2(store);
+  const arr = await zarr.open.v2(node.resolve('/X'), { kind: "array" });
+
+  if (arr instanceof zarr.Array) {
+    return await coordsFromZarr(arr);
+  }
+}
+
+const getURLParams = (): URLSearchParams => {
+  const queryString = window.location.search;
+  return new URLSearchParams(queryString);
+}
+
 
 export default function App() {
-  const viewers = useApplicationState((store) => store.viewers);
+  const viewers = useApplicationState((store) => store.viewers);;
+  const readHTTPStore = useApplicationState((s) => s.readHTTPStore);
+  const addViewer = useApplicationState((s) => s.addViewer);
+
+
+  useEffect(() => {
+    const urlParams = getURLParams();
+    const storePath = urlParams.get('store');
+    const varName = urlParams.get('var');
+    const time = new Date(urlParams.get('time'));
+    const channel = urlParams.get('channel');
+    const latStart = Number.parseFloat(urlParams.get('lat-start'));
+    const latStop = Number.parseFloat(urlParams.get('lat-stop'));
+    const lonStart = Number.parseFloat(urlParams.get('lon-start'));
+    const lonStop = Number.parseFloat(urlParams.get('lon-stop'));
+
+
+    async function getData() {
+
+      await readHTTPStore(storePath);
+      const coordsMap = await getCoords(storePath);
+      let timeIndex, channelIndex, latIndex, lonIndex;
+      latIndex = coordsMap.lat.sel({start: latStart, stop: latStop});
+      lonIndex = coordsMap.lon.sel({start: lonStart, stop: lonStop});
+      // timeIndex = coordsMap.time.isel({start: 421192, stop: 421195});
+      timeIndex = coordsMap.time.sel(time);
+      channelIndex = coordsMap.channel.isel(0);
+
+      const indices = [
+        timeIndex.zindex,
+        channelIndex.zindex,
+        latIndex.zindex,
+        lonIndex.zindex,
+      ]
+
+      addViewer({
+        path: `goes-fog-tomorrow-0.01-5min.zarr/${varName}`,
+        selection: indices, // [421192, 0, [12600, 12900], [5600, 5900]],
+        mapping: [3, 2],
+      });
+
+    };
+
+    getData();
+  }, []);
   return (
     <>
       {/* <React.StrictMode> */}

--- a/src/components/array-renderer.tsx
+++ b/src/components/array-renderer.tsx
@@ -32,18 +32,15 @@ const getRegion = async (
     } else return slice(value[0], value[1]);
   });
 
-  console.log(zarrIndex);
-
   let chunk = await get(store, zarrIndex);
 
   const bounds = chunk.data.reduce(
     (prev, value) => ({
-      min: Math.min(prev.min, value),
-      max: Math.max(prev.max, value),
+      min: Math.min(prev.min, Number.isNaN(value) ? Infinity : value),
+      max: Math.max(prev.max,  Number.isNaN(value) ? -Infinity : value),
     }),
     { max: -Infinity, min: Infinity }
   );
-
   return { chunk, bounds };
 };
 


### PR DESCRIPTION
Don't merge. This hijacks the main App and is just exploration for quick ways to render a scene + use labeled values.

Take a URL like this:

```
http://localhost:3000/
?store=http://localhost:3001/goes-fog-tomorrow-0.01-5min.zarr
&var=X
&time=2021-01-03T02:45:00.000Z
&lat-start=36
&lat-stop=39
&lon-start=-124
&lon-stop=-121
```
and select/render the viz.

https://github.com/user-attachments/assets/0f0c4e24-4451-4092-a20f-199de4531f4b

