### PR TITLE
Support labeled coordinate spaces.

### DIFF
--- a/src/components/selector/array-selector.tsx
+++ b/src/components/selector/array-selector.tsx
@@ -215,7 +215,6 @@ export default function ArraySelector({
   }
 
   const dims = tree.ref.shape;
-  const coords = store.coords;
   /**
    * NOTE(Nic): Name Heuristics could be implemented here...
    */
@@ -321,8 +320,10 @@ export default function ArraySelector({
         sel.push(parseInt(val))
       }
 
+      const prefix = viewer.path.split('/').slice(0, -1).join('/')
+      const coordKey = [prefix, names[i]].join('/');
+      const labelIdx: ArrayIndexer = store.coordinateIndexKeys[coordKey];
       const labelTarget = e.target.parentElement.parentElement.querySelector('.label');
-      const labelIdx: ArrayIndexer = coords[names[i]];
       const targetLabelValues = sel.map(v => labelIdx.valHuman(v));
       // TODO(Oli): use react ;)
       labelTarget.innerHTML = targetLabelValues.join(' - ');

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -2,6 +2,7 @@ import * as zarr from "zarrita";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { readStore } from "./read-metadata";
+import { CoordsMap } from "@/lib/larray";
 
 export type ZarrObject = zarr.Array<zarr.DataType, any> | zarr.Group<any>;
 
@@ -29,6 +30,8 @@ export type HTTPZarrStore = {
   loaded: boolean;
   keys: { [key: string]: ZarrTree };
   tree: ZarrTree;
+  // TODO(Oli): Consider making this optional/lazily populated.
+  coords: CoordsMap | null;
 };
 
 export type ZarrStore = HTTPZarrStore;

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -2,7 +2,7 @@ import * as zarr from "zarrita";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { readStore } from "./read-metadata";
-import { CoordsMap } from "@/lib/larray";
+import { ArrayIndexer, CoordsMap } from "@/lib/larray";
 
 export type ZarrObject = zarr.Array<zarr.DataType, any> | zarr.Group<any>;
 
@@ -30,8 +30,7 @@ export type HTTPZarrStore = {
   loaded: boolean;
   keys: { [key: string]: ZarrTree };
   tree: ZarrTree;
-  // TODO(Oli): Consider making this optional/lazily populated.
-  coords: CoordsMap | null;
+  coordinateIndexKeys: CoordsMap;
 };
 
 export type ZarrStore = HTTPZarrStore;

--- a/src/state/read-metadata.ts
+++ b/src/state/read-metadata.ts
@@ -9,10 +9,13 @@ import {
 } from "@/state";
 import { ArrayIndexer, CoordsMap, DateArrayIndexer, getIdxForSingleArr } from "@/lib/larray";
 
-const getCoords = async(root, keys: { [key: string]: ZarrTree }) => {
-  // populate coords mapping for the store
-  // TODO(oli): include store + group prefix in coord keys
-  debugger;
+/**
+ * Given a store root and key mapping for elements in our store, yield
+ * coordinate indices for all array coordinates found.
+ *
+ * @returns
+ */
+const getCoordsIndices = async(root: zarr.Group<any>, keys: { [key: string]: ZarrTree }): Promise<CoordsMap> => {
   const coords = {}
   for (let [k, v] of Object.entries(keys)) {
     if (v.type == "array") {
@@ -20,14 +23,18 @@ const getCoords = async(root, keys: { [key: string]: ZarrTree }) => {
       if (!Array.isArray(dims)) {
         throw new Error("Dims is not an array");
       }
+      const parts = k.split('/')
+      const prefix = parts.slice(0, -1).join('/');
       for (const dimName of dims) {
-        if (dimName in coords) {
+        const coordKey = `${prefix}/${dimName}`
+        // don't refetch if we've already retrieve these coords
+        if (coordKey in coords) {
           continue;
         }
-        const coordArray = await zarr.open(root.resolve(`/${dimName}`), {
+        const coordArray = await zarr.open(root.resolve(`${dimName}`), {
           kind: "array",
         });
-        coords[dimName] = await getIdxForSingleArr(dimName, coordArray);
+        coords[coordKey] = await getIdxForSingleArr(dimName, coordArray);
       }
     }
   }
@@ -116,9 +123,12 @@ export const readStore = async (
   try {
     let zarrStore = await zarr.tryWithConsolidated(new zarr.FetchStore(uri));
     let root = await zarr.open(zarrStore);
-
     try {
       // object is a group
+      // TODO(oli/nic): refactor the try/catch if/else's here.q
+      if (!(root.kind == "group")) {
+        throw Error("Can not process non-group")
+      }
       const contents: { path: string; kind: string }[] = zarrStore.contents();
 
       const data = await Promise.all(
@@ -129,16 +139,15 @@ export const readStore = async (
 
       const { tree, keys } = buildtree(uri, data);
 
-      const coords = await getCoords(root, keys);
-
       const result: ZarrStore = {
         type: "http",
         uri,
         loaded: true,
         keys,
         tree,
-        coords
+        coordinateIndexKeys: await getCoordsIndices(root, keys)
       };
+
       return result;
     } catch (e) {
       // object is an array
@@ -157,22 +166,27 @@ export const readStore = async (
         children: {},
       };
 
-      const coords = await getCoords(root, { [record.path]: record });
-
+      // to look up coords, we need a root from which to resolve them
+      // make a root store at the group/root holding the array
+      const prefixUri = arrayPath.slice(0, arrayPath.length-1).join('/');
+      const zarrStore = new zarr.FetchStore(prefixUri);
+      const tmpRoot = await zarr.open(zarrStore);
+      if (!(tmpRoot.kind == "group")) {
+        throw Error("Unable to identify array root group")
+      }
+      const coords = await getCoordsIndices(tmpRoot, { [record.path]: record });
       const result: ZarrStore = {
         type: "http",
         uri,
         loaded: true,
         keys: { [record.path]: record },
         tree: record,
-        coords
+        coordinateIndexKeys: coords
       };
 
       return result;
     }
 
-    // const arr = await zarr.open(zarrStore);
-    // console.log(arr);
   } catch (e) {
     return {
       type: "error",


### PR DESCRIPTION
This change adds functionality to load and use coordinate values (rather than indices) when inspecting an array. For now, it simply prints real values from index selections as a user configures their view.

Because it's common to share coordinates across many vars, coords are persisted in similar fashion to keys, and available directly via the store object as `coordinateIndexKeys`. We can think about whether we like this and move it around as we see fit.

CoordsMap maps a coordinate name => `ArrayIndexer`. An ArrayIndexer sits on top of a coordinate array and provides some utilities to slice into that array based on values (`sel`) or indices (`isel`). We're not directly using these for now. It also provides some poorly named helpers like `valHuman(idx)` to get a real value out of the underlying array based on an index. 

Todo to wrap this up:
- [x] Breaks if an array (rather than root store) is provided to `readStore`, fix this.
- [ ] Some typing and naming cleanup in larray
- [ ] Some minor UX items, like rendering labels on load for the default 0th index