### PR TITLE
Support arrays without metadata or coordinates

### DIFF
--- a/src/components/browser/add-store-button.tsx
+++ b/src/components/browser/add-store-button.tsx
@@ -63,8 +63,8 @@ export default function AddStoreButton({
         if (maybeURI.length > 0 && inputRef.current.validity.valid) {
           setUIState({ state: "loading" });
           const storeOrError = await readStore(maybeURI);
-
           if (resultIsError(storeOrError)) {
+            console.log(storeOrError.message);
             setUIState({ state: "error" });
           } else {
             setUIState({ state: "normal" });

--- a/src/components/selector/array-selector.tsx
+++ b/src/components/selector/array-selector.tsx
@@ -293,12 +293,14 @@ export default function ArraySelector({
       const coordKey = [prefix, names[i]].join("/");
       const labelIdx: ArrayIndexer = store.coordinateIndexKeys[coordKey];
 
-      if (typeof sel === "number") {
-        labels[i].value = labelIdx.valHuman(sel);
-      } else if (sel === null) {
-        labels[i].value = ":";
-      } else if (typeof sel === "object") {
-        labels[i].value == sel.map((v) => labelIdx.valHuman(v)).join(":");
+      if (labelIdx) {
+        if (typeof sel === "number") {
+          labels[i].value = labelIdx.valHuman(sel);
+        } else if (sel === null) {
+          labels[i].value = ":";
+        } else if (typeof sel === "object") {
+          labels[i].value == sel.map((v) => labelIdx.valHuman(v)).join(":");
+        }
       }
     }
   }, [viewer, focus.region]);
@@ -355,6 +357,7 @@ export default function ArraySelector({
     };
 
   const setNewValues = (val, i, labelTarget) => {
+
     if (!isIntegerOrSlice(val)) {
       setLocalUI((p) => ({ ...p, errorDims: [i, ...p.errorDims] }));
     } else {
@@ -406,16 +409,18 @@ export default function ArraySelector({
         newViewerSpec.selection = newViewerSpec.selection.map((v, j) =>
           j === i ? parseInt(val) : v
         );
-
         sel.push(parseInt(val));
       }
+
 
       const prefix = viewer.path.split("/").slice(0, -1).join("/");
       const coordKey = [prefix, names[i]].join("/");
       const labelIdx: ArrayIndexer = store.coordinateIndexKeys[coordKey];
-      const targetLabelValues = sel.map((v) => labelIdx.valHuman(v));
-      // TODO(Oli): use react ;)
-      labelTarget.value = targetLabelValues.join(" : ");
+      if (labelIdx) {
+        const targetLabelValues = sel.map(v => labelIdx.valHuman(v));
+        // TODO(Oli): use react ;)
+        labelTarget.value = targetLabelValues.join(' : ');
+      }
       updateViewer(viewerIdx, newViewerSpec);
     }
   };


### PR DESCRIPTION
This change loosens the requirement on consolidated metadata and the presence of coordinates with an array. If no metadata is found, and the provided type is an array, render the array with indexing support only.

The pursuit was loosely based on rendering OME data, so includes some other small tweaks, for example casting int -> float arrays for rendering if provided type is such.

https://github.com/user-attachments/assets/b4fd812f-6e7b-46c0-85b8-24c01723e095

